### PR TITLE
Add sample iOS product price map

### DIFF
--- a/ios_product_price_map_sample.csv
+++ b/ios_product_price_map_sample.csv
@@ -1,0 +1,4 @@
+product_id,price,currency,introductory_price,date,duration
+premium_weekly,4.99,USD,0.99,2021-09-13,P1W
+premium_weekly,8.99,CAD,1.99,2021-09-13,P1W
+premium_weekly,5.99,USD,0.99,2020-01-01,P1W


### PR DESCRIPTION
We mention adding a supplemental CSV file with products and prices in [the iOS section](https://docs.revenuecat.com/docs/migrating-existing-subscriptions#bulk-imports) but don't have a sample for it.